### PR TITLE
スコアカードにランクを表示するように変更

### DIFF
--- a/lib/constants/values.dart
+++ b/lib/constants/values.dart
@@ -38,4 +38,12 @@ enum ScoreClass {
     }
     return ScoreClass.c;
   }
+
+  String get rankText {
+    return switch (this) {
+      a => 'ランクA',
+      b => 'ランクB',
+      c => 'ランクC',
+    };
+  }
 }

--- a/lib/presentation/components/score_card.dart
+++ b/lib/presentation/components/score_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:ggc/constants/values.dart';
-import 'package:ggc/presentation/game/turtle_escape.dart';
 import 'package:ggc/util/format_duration.dart';
 
 class ScoreCard extends StatelessWidget {

--- a/lib/presentation/components/score_card.dart
+++ b/lib/presentation/components/score_card.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:ggc/constants/values.dart';
+import 'package:ggc/presentation/game/turtle_escape.dart';
 import 'package:ggc/util/format_duration.dart';
 
 class ScoreCard extends StatelessWidget {
@@ -15,6 +17,7 @@ class ScoreCard extends StatelessWidget {
       valueListenable: score,
       builder: (context, score, child) {
         final formatted = formatDuration(score);
+        final rank = ScoreClass.fromInt(score);
         return DecoratedBox(
           decoration: const BoxDecoration(
             gradient: LinearGradient(
@@ -42,6 +45,12 @@ class ScoreCard extends StatelessWidget {
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
                 ),
+                score != 0
+                    ? Text(
+                        rank.rankText,
+                        style: Theme.of(context).textTheme.titleLarge,
+                      )
+                    : const SizedBox.shrink(),
               ],
             ),
           ),


### PR DESCRIPTION
SSIA

ランキングに入れるとバランス崩れちゃうので、スコアカードに表示するようにしました！

<img src="https://github.com/miyasic/ggc/assets/62228968/e7cd73e6-d5dc-4664-9b4d-676b360f5462" width="200">
