### PR TITLE
Resolve Google Play Memory Page Size Warning

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
+android.bundle.enableUncompressedNativeLibs=false


### PR DESCRIPTION
Add android.bundle.enableUncompressedNativeLibs=false to gradle.properties to support 16KB memory page size requirement for Google Play Console.

This configuration ensures native libraries are compressed in the bundle, allowing the app to work correctly on devices with 16KB page size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)