### PR TITLE
feat: Support 16KB page size and update to API level 35

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,7 +31,7 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace "com.example.ggc"
     compileSdkVersion flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    ndkVersion "28.0.12674087"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace "com.example.ggc"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdkVersion 35
     ndkVersion "28.0.12674087"
 
     compileOptions {
@@ -52,7 +52,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,7 +23,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version "8.5.1" apply false
 }
 
 include ":app"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ggc
 description: "A new Flutter project for GGC"
 publish_to: "none"
 
-version: 1.0.0+2
+version: 1.0.1+4
 
 environment:
   sdk: "^3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ggc
 description: "A new Flutter project for GGC"
 publish_to: "none"
 
-version: 1.0.1+4
+version: 1.0.1+5
 
 environment:
   sdk: "^3.0.0"


### PR DESCRIPTION
## Summary
- Google Play Console の 16KB ページサイズ対応要件に対応
- Android API レベル 35 へ更新
- アプリバージョンを 1.0.1+5 に更新

## Changes
### 16KB ページサイズ対応
- AGP を 7.3.0 から 8.5.1 に更新
- Gradle を 7.5 から 8.7 に更新
- NDK 28 を明示的に指定（16KB 対応版）

### API レベル対応
- compileSdkVersion を 35 に更新
- targetSdkVersion を 35 に更新

### バージョン管理
- アプリバージョンを 1.0.0+2 から 1.0.1+5 に更新

## Test plan
- [x] App Bundle のビルドが成功することを確認
- [x] Google Play Console にアップロードして 16KB 警告が消えることを確認
- [x] API レベル 35 の要件を満たしていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)